### PR TITLE
Add exception handling to build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/rt-net/RaspberryPiMouse.svg?branch=master)](https://travis-ci.org/rt-net/RaspberryPiMouse)
 
 This repository has the source code and kernel objects
-for the Raspberry Pi mouse.
+for the Raspberry Pi Mouse.
 
 ## インストール
 
@@ -13,9 +13,11 @@ for the Raspberry Pi mouse.
 $ git clone https://github.com/rt-net/RaspberryPiMouse.git
 $ cd utils
 ###Raspbianの場合###
-$ ./build_install.raspbian.bash
-###Ubuntuの場合（ubuntu14とありますがUbuntu Linux 16.04でもインストール可能です）###
-$ ./build_install.ubuntu14.bash
+$ sudo apt install raspberrypi-kernel-headers
+$ ./build_install.bash
+###Ubuntuの場合###
+$ sudo apt install linux-headers-$(uname -r)
+$ ./build_install.bash
 ```
 
 
@@ -40,6 +42,7 @@ $ sudo insmod rtmouse.ko
 `raspi-config` コマンドで設定します。
 
 * SPI機能を「入」にする。
+* I2C機能を「入」にする。
 
 2017年1月現在、以下の設定は不要です。  
 rtmouseをインストールして不具合が出た場合のみ以下の設定を追加で行ってください。
@@ -77,6 +80,6 @@ This repository contains the code of the repository shown below.
 このリポジトリは以下に示すリポジトリのコードを一部含みます。
 
 * [take-iwiw/DeviceDriverLesson](https://github.com/take-iwiw/DeviceDriverLesson)
-  * BSD License
+  * GPL/BSD License
 * [mcp3204.c in Raspberry Piで学ぶARMデバイスドライバープログラミング](http://www.socym.co.jp/support/s-940#ttlDownload)
   * GPL v2 License

--- a/utils/build_install.bash
+++ b/utils/build_install.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+SRC_DIR=$(cd $(dirname ${BASH_SOURCE:-$0})/../; pwd)
+
+if [ -e /usr/src/linux ]; then
+	$SRC_DIR/utils/build_install.raspbian.bash && exit 0
+elif [ "$(ls /usr/src/linux-* 2> /dev/null)" != '' ]; then
+	$SRC_DIR/utils/build_install.ubuntu14.bash && exit 0
+else
+	bash -e $SRC_DIR/utils/print_env.bash "No kernel header files found."
+fi
+

--- a/utils/build_install.raspbian.bash
+++ b/utils/build_install.raspbian.bash
@@ -1,7 +1,7 @@
 #!/bin/bash -vxe
 
 dir=$(dirname $0)/../
-
+[ ! -e /usr/src/linux ] && { bash -e $dir/utils/print_env.bash "No kernel header files found."; exit 1; }
 cd $dir/src/drivers/
 rm Makefile
 ln -s Makefile.raspbian Makefile

--- a/utils/build_install.ubuntu14.bash
+++ b/utils/build_install.ubuntu14.bash
@@ -1,12 +1,12 @@
 #!/bin/bash -vxe
 
 dir=$(dirname $0)/../
-
+[ ! -e /usr/src/linux-headers-$(uname -r) ] && { bash -e $dir/utils/print_env.bash "No kernel header files found."; exit 1; }
 cd $dir/src/drivers/
 rm Makefile
 ln -s Makefile.ubuntu14 Makefile
 make clean
-make 
+make
 sudo insmod rtmouse.ko
 sleep 1
 sudo chmod 666 /dev/rt*

--- a/utils/print_env.bash
+++ b/utils/print_env.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -u
+set +exv
+
+echo "==================="
+echo "ERROR: $@"
+echo "If you need someone's support, you should share this information."
+uname -a
+lsb_release -a || cat /etc/lsb-release
+ls /usr/src/linux*
+echo "==================="


### PR DESCRIPTION
This PR has two new features.

An exception handling to `./build_install.*.bash`

```
pi@raspberrypi:~/RaspberryPiMouse
$ ./utils/build_install.ubuntu14.bash
#!/bin/bash -vxe

dir=$(dirname $0)/../
++ dirname ./utils/build_install.ubuntu14.bash
+ dir=./utils/../

[ ! -e /usr/src/linux-headers-$(uname -r) ] && { bash -e $dir/utils/print_env.bash "No kernel header files found."; exit 1; }
++ uname -r
+ '[' '!' -e /usr/src/linux-headers-4.14.98-v7+ ']'
+ bash -e ./utils/..//utils/print_env.bash 'No kernel header files found.'
===================
ERROR: No kernel header files found.
If you need someone's support, you should share this information.
Linux raspberrypi 4.14.98-v7+ #1200 SMP Tue Feb 12 20:27:48 GMT 2019 armv7l GNU/Linux
No LSB modules are available.
Distributor ID:	Raspbian
Description:	Raspbian GNU/Linux 9.8 (stretch)
Release:	9.8
Codename:	stretch
ls: cannot access '/usr/src/linux*': No such file or directory
===================
+ exit 1
```

An automatic environment identification script `build_install.bash`
This script automatically determines whether to execute `build_install.ubuntu14.bash` or `build_install.raspbian.bash`.
If there are no kernel header files, the following error will be shown:

```
pi@raspberrypi:~/RaspberryPiMouse/utils
$ ./build_install.bash
===================
ERROR: No kernel header files found.
If you need someone's support, you should share this information.
Linux raspberrypi 4.14.98-v7+ #1200 SMP Tue Feb 12 20:27:48 GMT 2019 armv7l GNU/Linux
No LSB modules are available.
Distributor ID:	Raspbian
Description:	Raspbian GNU/Linux 9.8 (stretch)
Release:	9.8
Codename:	stretch
ls: cannot access '/usr/src/linux*': No such file or directory
===================
```