### PR TITLE
Add signed counter (rtcounter_l1, rtcounter_r1)

### DIFF
--- a/src/drivers/rtmouse.c
+++ b/src/drivers/rtmouse.c
@@ -267,8 +267,8 @@ static struct mutex lock;
 #define MCP3204_CHANNELS 4
 
 /* I2C Parameter */
-#define DEV_ADDR_CNTR 0x10
-#define DEV_ADDR_CNTL 0x11
+#define DEV_ADDR_CNTL 0x10
+#define DEV_ADDR_CNTR 0x11
 #define CNT_ADDR_MSB 0x10
 #define CNT_ADDR_LSB 0x11
 
@@ -1963,9 +1963,9 @@ static int i2c_counter_init(void)
 	struct i2c_adapter *i2c_adap_l;
 	struct i2c_adapter *i2c_adap_r;
 	struct i2c_board_info i2c_board_info_l = {
-	    I2C_BOARD_INFO(DEVNAME_CNTL, 0x10)};
+	    I2C_BOARD_INFO(DEVNAME_CNTL, DEV_ADDR_CNTL)};
 	struct i2c_board_info i2c_board_info_r = {
-	    I2C_BOARD_INFO(DEVNAME_CNTR, 0x11)};
+	    I2C_BOARD_INFO(DEVNAME_CNTR, DEV_ADDR_CNTR)};
 
 	// printk(KERN_DEBUG "%s: initializing i2c device", __func__);
 	retval = i2c_add_driver(&i2c_counter_driver);

--- a/src/drivers/rtmouse.c
+++ b/src/drivers/rtmouse.c
@@ -67,7 +67,7 @@ MODULE_DESCRIPTION("Raspberry Pi Mouse device driver");
 #define NUM_DEV_MOTORRAWL 1
 #define NUM_DEV_MOTOREN 1
 #define NUM_DEV_MOTOR 1
-#define NUM_DEV_CNT 1
+#define NUM_DEV_CNT 2
 
 #define NUM_DEV_TOTAL                                                          \
 	(NUM_DEV_LED + NUM_DEV_SWITCH + NUM_DEV_BUZZER + NUM_DEV_MOTORRAWR +   \
@@ -2059,7 +2059,7 @@ int dev_init_module(void)
 
 	retval = i2c_counter_init();
 	if (retval == 0) {
-		registered_devices += 2;
+		registered_devices += 2 * NUM_DEV_CNT;
 	}
 	else{
 		printk(KERN_ALERT

--- a/src/drivers/rtmouse.c
+++ b/src/drivers/rtmouse.c
@@ -3,7 +3,7 @@
  * rtmouse.c
  * Raspberry Pi Mouse device driver
  *
- * Version: 2.0.0
+ * Version: 2.1.0
  *
  * Copyright (C) 2015-2020 RT Corporation <shop@rt-net.jp>
  *
@@ -55,7 +55,7 @@
 
 MODULE_AUTHOR("RT Corporation");
 MODULE_LICENSE("GPL");
-MODULE_VERSION("2.0.0");
+MODULE_VERSION("2.1.0");
 MODULE_DESCRIPTION("Raspberry Pi Mouse device driver");
 
 /* --- Device Numbers --- */

--- a/src/drivers/rtmouse.c
+++ b/src/drivers/rtmouse.c
@@ -330,6 +330,8 @@ struct rtcnt_device_info {
 
 static struct i2c_client *i2c_client_r = NULL;
 static struct i2c_client *i2c_client_l = NULL;
+static unsigned int motor_l_freq_is_positive = 1;
+static unsigned int motor_r_freq_is_positive = 1;
 
 /* I2C Device ID */
 static struct i2c_device_id i2c_counter_id[] = {
@@ -468,8 +470,10 @@ static void set_motor_l_freq(int freq)
 	}
 
 	if (freq > 0) {
+		motor_l_freq_is_positive = 1;
 		rpi_gpio_clear32(RPI_GPIO_P2MASK, 1 << MOTDIR_L_BASE);
 	} else {
+		motor_l_freq_is_positive = 0;
 		rpi_gpio_set32(RPI_GPIO_P2MASK, 1 << MOTDIR_L_BASE);
 		freq = -freq;
 	}
@@ -497,8 +501,10 @@ static void set_motor_r_freq(int freq)
 	}
 
 	if (freq > 0) {
+		motor_r_freq_is_positive = 1;
 		rpi_gpio_set32(RPI_GPIO_P2MASK, 1 << MOTDIR_R_BASE);
 	} else {
+		motor_r_freq_is_positive = 0;
 		rpi_gpio_clear32(RPI_GPIO_P2MASK, 1 << MOTDIR_R_BASE);
 		freq = -freq;
 	}

--- a/src/drivers/rtmouse.c
+++ b/src/drivers/rtmouse.c
@@ -1173,10 +1173,10 @@ static int i2c_counter_read(struct rtcnt_device_info *dev_info, int *ret)
 }
 
 /*
- * set_signed_count - set signed pulse count to dev_info
+ * update_signed_count - update signed pulse count of dev_info
  * called by rtcnt_read()
  */
-void set_signed_count(struct rtcnt_device_info *dev_info,
+void update_signed_count(struct rtcnt_device_info *dev_info,
 	int rtcnt_count)
 {
 	int diff_count = rtcnt_count - dev_info->raw_pulse_count;
@@ -1246,7 +1246,7 @@ static ssize_t rtcnt_read(struct file *filep, char __user *buf, size_t count,
 	i2c_counter_read(dev_info, &rtcnt_count);
 
 	if(dev_info->device_minor == 1){
-		set_signed_count(dev_info, rtcnt_count);
+		update_signed_count(dev_info, rtcnt_count);
 		dev_info->raw_pulse_count = rtcnt_count;
 		rtcnt_count = dev_info->signed_pulse_count;
 	}else{


### PR DESCRIPTION
正負の値を持つパルスカウンタデバイスを追加しました。

- `/dev/rtcounter_l1`と`/dev/rtcounter_r1`を新たに追加
- モータが正転（`/dev/rtmotor_raw` > 0）するとカウントアップ
- モータが逆転（`/dev/rtmotor_raw` < 0）するとカウントダウン
- 最大、最小値は±32767で、この値を超えると0にリセットされる
- `/dev/rtcounter_l1, r1`には負の値を書き込める
  - ±32767を超える値は、±32767に制限される
- `/dev/rtcounter_l1, r1`に値を書き込むと、`/dev/rtcounter_l0, r0`の値も変わる
  - これは仕様
  - `l1, r1`と`l0, r0`を同時に使わない想定で実装している

will close #31 