### PR TITLE
I2Cのボーレート確認方法を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ I2Cのbaudrateをデフォルト値より下げる必要があります（[issue
 dtparam=i2c_baudrate=62500
 ```
 
+現在設定されているI2Cのbaudrateは以下のコマンドを実行することで確認できます。
+
+```
+$ printf "%d\n" 0x$(xxd -ps /sys/class/i2c-adapter/i2c-1/of_node/clock-frequency)
+```
+
 ### Raspberry Pi 4
 
 Raspberry Pi 4ではCPUのレジスタがそれまでのRaspberry Piとは異なります（[issues#21](https://github.com/rt-net/RaspberryPiMouse/issues/21)）。  


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.

# What does this implement/fix? Explain your changes.
<!-- このPRはどんな機能改善/修正ですか？ -->
I2Cのボーレートを確認する方法を追記しました

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
Raspbian/Ubuntuで以下のコマンドを実行してボーレートを取得できることを確認しました。

```
$ printf "%d\n" 0x$(xxd -ps /sys/class/i2c-adapter/i2c-1/of_node/clock-frequency)
```