### PR TITLE
Use kstrtoint_from_user() instead of parseFreq() and parse_count() to detect parse error.

### DIFF
--- a/src/drivers/rtmouse.c
+++ b/src/drivers/rtmouse.c
@@ -3,7 +3,7 @@
  * rtmouse.c
  * Raspberry Pi Mouse device driver
  *
- * Version: 3.1.0
+ * Version: 3.1.1
  *
  * Copyright (C) 2015-2021 RT Corporation <shop@rt-net.jp>
  *
@@ -55,7 +55,7 @@
 
 MODULE_AUTHOR("RT Corporation");
 MODULE_LICENSE("GPL");
-MODULE_VERSION("3.0.0");
+MODULE_VERSION("3.1.1");
 MODULE_DESCRIPTION("Raspberry Pi Mouse device driver");
 
 /* --- Device Numbers --- */

--- a/src/drivers/rtmouse.c
+++ b/src/drivers/rtmouse.c
@@ -848,59 +848,6 @@ static int i2c_dev_release(struct inode *inode, struct file *filep)
 	return 0;
 }
 
-/* Parse Frequency */
-static int parseFreq(const char __user *buf, size_t count, int *ret)
-{
-	char cval;
-	int error = 0, i = 0, tmp, bufcnt = 0, freq;
-	size_t readcount = count;
-	int sgn = 1;
-
-	char *newbuf = kmalloc(sizeof(char) * count, GFP_KERNEL);
-
-	while (readcount > 0) {
-		if (copy_from_user(&cval, buf + i, sizeof(char))) {
-			kfree(newbuf);
-			return -EFAULT;
-		}
-
-		if (cval == '-') {
-			if (bufcnt == 0) {
-				sgn = -1;
-			}
-		} else if (cval < '0' || cval > '9') {
-			newbuf[bufcnt] = 'e';
-			error = 1;
-		} else {
-			newbuf[bufcnt] = cval;
-		}
-
-		i++;
-		bufcnt++;
-		readcount--;
-
-		if (cval == '\n') {
-			break;
-		}
-	}
-
-	freq = 0;
-	for (i = 0, tmp = 1; i < bufcnt; i++) {
-		char c = newbuf[bufcnt - i - 1];
-
-		if (c >= '0' && c <= '9') {
-			freq += (newbuf[bufcnt - i - 1] - '0') * tmp;
-			tmp *= 10;
-		}
-	}
-
-	*ret = sgn * freq;
-
-	kfree(newbuf);
-
-	return bufcnt;
-}
-
 /* Parse motor command  */
 static int parseMotorCmd(const char __user *buf, size_t count, int *ret)
 {
@@ -931,58 +878,6 @@ static int parseMotorCmd(const char __user *buf, size_t count, int *ret)
 	return count;
 }
 
-/* Parse I2C pulse counter value */
-static int parse_count(const char __user *buf, size_t count, int *ret)
-{
-	char cval;
-	int error = 0, i = 0, tmp, bufcnt = 0, freq;
-	size_t readcount = count;
-	int sgn = 1;
-
-	char *newbuf = kmalloc(sizeof(char) * count, GFP_KERNEL);
-
-	while (readcount > 0) {
-		if (copy_from_user(&cval, buf + i, sizeof(char))) {
-			kfree(newbuf);
-			return -EFAULT;
-		}
-
-		if (cval == '-') {
-			if (bufcnt == 0) {
-				sgn = -1;
-			}
-		} else if (cval < '0' || cval > '9') {
-			newbuf[bufcnt] = 'e';
-			error = 1;
-		} else {
-			newbuf[bufcnt] = cval;
-		}
-
-		i++;
-		bufcnt++;
-		readcount--;
-
-		if (cval == '\n') {
-			break;
-		}
-	}
-
-	freq = 0;
-	for (i = 0, tmp = 1; i < bufcnt; i++) {
-		char c = newbuf[bufcnt - i - 1];
-
-		if (c >= '0' && c <= '9') {
-			freq += (newbuf[bufcnt - i - 1] - '0') * tmp;
-			tmp *= 10;
-		}
-	}
-
-	*ret = sgn * freq;
-
-	kfree(newbuf);
-
-	return bufcnt;
-}
 
 /*
  * led_write - Trun ON/OFF LEDs
@@ -1019,10 +914,15 @@ static ssize_t led_write(struct file *filep, const char __user *buf,
 static ssize_t buzzer_write(struct file *filep, const char __user *buf,
 			    size_t count, loff_t *f_pos)
 {
-	int bufcnt;
+	int ret;
 	int freq, dat;
 
-	bufcnt = parseFreq(buf, count, &freq);
+	ret = kstrtoint_from_user(buf, count, 10, &freq);
+	if (ret) {
+		printk(KERN_ERR "%s: error parsing string to int in %s()\n",
+		       DRIVER_NAME, __func__);
+		return ret;
+	}
 
 	if (freq != 0) {
 		if (freq < 1) {
@@ -1043,7 +943,7 @@ static ssize_t buzzer_write(struct file *filep, const char __user *buf,
 				      RPI_GPF_OUTPUT); // io is pwm out
 	}
 
-	return bufcnt;
+	return count;
 }
 
 /*
@@ -1053,12 +953,17 @@ static ssize_t buzzer_write(struct file *filep, const char __user *buf,
 static ssize_t rawmotor_l_write(struct file *filep, const char __user *buf,
 				size_t count, loff_t *f_pos)
 {
-	int freq, bufcnt;
-	bufcnt = parseFreq(buf, count, &freq);
+	int freq, ret;
 
+	ret = kstrtoint_from_user(buf, count, 10, &freq);
+	if (ret) {
+		printk(KERN_ERR "%s: error parsing string to int in %s()\n",
+		       DRIVER_NAME, __func__);
+		return ret;
+	}
 	set_motor_l_freq(freq);
 
-	return bufcnt;
+	return count;
 }
 
 /*
@@ -1068,12 +973,18 @@ static ssize_t rawmotor_l_write(struct file *filep, const char __user *buf,
 static ssize_t rawmotor_r_write(struct file *filep, const char __user *buf,
 				size_t count, loff_t *f_pos)
 {
-	int freq, bufcnt;
-	bufcnt = parseFreq(buf, count, &freq);
+	int freq, ret;
+
+	ret = kstrtoint_from_user(buf, count, 10, &freq);
+	if (ret) {
+		printk(KERN_ERR "%s: error parsing string to int in %s()\n",
+		       DRIVER_NAME, __func__);
+		return ret;
+	}
 
 	set_motor_r_freq(freq);
 
-	return bufcnt;
+	return count;
 }
 
 /*
@@ -1292,13 +1203,15 @@ static ssize_t rtcnt_write(struct file *filep, const char __user *buf,
 {
 	struct rtcnt_device_info *dev_info = filep->private_data;
 
-	int bufcnt = 0;
 	int rtcnt_count = 0;
+	int ret;
 
-	if (count < 0)
-		return 0;
-
-	bufcnt = parse_count(buf, count, &rtcnt_count);
+	ret = kstrtoint_from_user(buf, count, 10, &rtcnt_count);
+	if (ret) {
+		printk(KERN_ERR "%s: error parsing string to int in %s()\n",
+		       DRIVER_NAME, __func__);
+		return ret;
+	}
 
 	i2c_counter_set(dev_info, rtcnt_count);
 
@@ -1308,7 +1221,7 @@ static ssize_t rtcnt_write(struct file *filep, const char __user *buf,
 
 	printk(KERN_INFO "%s: set pulse counter value %d\n", DRIVER_NAME,
 	       rtcnt_count);
-	return bufcnt;
+	return count;
 }
 
 /* --- Device File Operations --- */


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

Raspberry Pi OS（debian 10.10、kernel 5.10.17）でサンプルプログラムのstep4.shを実行した際、
モータが回らないタイミングがあることを確認しました。

`parseFreq()`で`newbuf`のメモリを確保する際に、ゼロで初期化していないことが原因です。
メモリの確保に`kzalloc()`を使用し、確保したメモリにゼロをセットすることで問題が解決しました。

## 不具合の詳細

`newbuf`が生成されたときに、その中身が`4????`のような数字で始まる場合、
かつ、
セットしたいモータ速度が`-300`のように先頭がマイナスの場合に問題が発生します。

指示値が`-300`のとき、指示値をパースした後`newbuf = " 300"`となるのが理想ですが、
`newbuf[0]`の初期値に数字が入っていると、パース後は`newbuf = "4300"`となってしまいます。

その後、符号が処理されるので、最終的に`-4300`がモータにセットされます。
これは指示範囲外なので、モータが回りません。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

Raspberry Pi OSと、Ubuntu 20.04にて、step4.shを実行した際にモータが正常に回ることを確認してます。

# Any other comments?
<!-- その他コメントはありますか？ -->

いいえ

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
