### PR TITLE
Reset uncontrollable motor frequency to zero.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,16 @@ $ echo 1 > /dev/rtmotoren0
 
 ### PWM frequency for left/right motor driver (Output)
 
-Write 0 ~ 10000 to `/dev/rtmotor_raw_l0` or `/dev/rtmotor_raw_r0` to set PWM frequency for motor drivers.
+Write 0 ~ ±10000 to `/dev/rtmotor_raw_l0` or `/dev/rtmotor_raw_r0` to set PWM frequency for motor drivers.
 
-`/dev/rtmotor_raw_l0` または `/dev/rtmotor_raw_r0` に 0 ~ 10000 を書き込み、モータドライバへのPWM周波数を設定します。
+※ 0 ~ ±4 Hz will be reset to 0 Hz.
+
+`/dev/rtmotor_raw_l0` または `/dev/rtmotor_raw_r0` に 0 ~ ±10000 を書き込み、モータドライバへのPWM周波数を設定します。
+
+※ 0 ~ ±4 Hzは0Hzへリセットされます
 
 ```sh
-# echo 0 ~ 10000(Hz) > /dev/rtmotor_raw_[l0, r0]
+# echo 0 ~ ±10000(Hz) > /dev/rtmotor_raw_[l0, r0]
 $ echo 1 > /dev/rtmotoren0
 $ echo 400 > /dev/rtmotor_raw_l0
 ```

--- a/src/drivers/rtmouse.c
+++ b/src/drivers/rtmouse.c
@@ -272,6 +272,9 @@ static struct mutex lock;
 #define CNT_ADDR_MSB 0x10
 #define CNT_ADDR_LSB 0x11
 
+/* Motor Parameter */
+#define MOTOR_UNCONTROLLABLE_FREQ 5
+
 /* --- Function Declarations --- */
 static void set_motor_r_freq(int freq);
 static void set_motor_l_freq(int freq);
@@ -467,6 +470,11 @@ static void set_motor_l_freq(int freq)
 
 	rpi_gpio_function_set(BUZZER_BASE, RPI_GPF_OUTPUT);
 
+	// Reset uncontrollable frequency to zero.
+	if (abs(freq) < MOTOR_UNCONTROLLABLE_FREQ) {
+		freq = 0;
+	}
+
 	if (freq == 0) {
 		rpi_gpio_function_set(MOTCLK_L_BASE, RPI_GPF_OUTPUT);
 		return;
@@ -497,6 +505,11 @@ static void set_motor_r_freq(int freq)
 	int dat;
 
 	rpi_gpio_function_set(BUZZER_BASE, RPI_GPF_OUTPUT);
+
+	// Reset uncontrollable frequency to zero.
+	if (abs(freq) < MOTOR_UNCONTROLLABLE_FREQ) {
+		freq = 0;
+	}
 
 	if (freq == 0) {
 		rpi_gpio_function_set(MOTCLK_R_BASE, RPI_GPF_OUTPUT);

--- a/src/drivers/rtmouse.c
+++ b/src/drivers/rtmouse.c
@@ -3,7 +3,7 @@
  * rtmouse.c
  * Raspberry Pi Mouse device driver
  *
- * Version: 3.1.1
+ * Version: 3.2.0
  *
  * Copyright (C) 2015-2021 RT Corporation <shop@rt-net.jp>
  *
@@ -55,7 +55,7 @@
 
 MODULE_AUTHOR("RT Corporation");
 MODULE_LICENSE("GPL");
-MODULE_VERSION("3.1.1");
+MODULE_VERSION("3.2.0");
 MODULE_DESCRIPTION("Raspberry Pi Mouse device driver");
 
 /* --- Device Numbers --- */


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

モータのPWM周波数が小さい時（< 5Hz）に、周波数を0にリセットします。


## 変更の背景

（エビデンスを見つけられていませんが）Rapsberry Piは、PWMパルスを1周期出力し終えるまで、PWM周波数を変えることができないようです。
そのため、1 HzのPWM周波数を設定すると、1秒間はモータを回すことができません。（回そうとしますが、回りません）

この仕様は、ジョイスティックコントローラでラズパイマウスを操作する際に影響します。
スティックを倒してラズパイマウスを走らせる場合、一瞬でも1 Hzの周波数を設定してしまうと、スティックを倒したにもかかわらずラズパイマウスが動かない、という状況が発生します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
Ubuntu 20.04 で、±5 Hz からモータが回ることを確認しました。

```sh
$ echo 1 > /dev/rtmotoren0
$ echo 1 > /dev/rtmotor_raw_l0
$ echo 1 > /dev/rtmotor_raw_r0
$ echo 5 > /dev/rtmotor_raw_l0
$ echo 5 > /dev/rtmotor_raw_r0
```

# Any other comments?
<!-- その他コメントはありますか？ -->

周波数の下限値が5 Hzで良いかは判断が難しいです。
下限値を大きくしすぎると細かい制御が効かなくなるので、感覚で適度な値を選びました。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
