### PR TITLE
Remove gcc ver 6.3 from CI

### DIFF
--- a/.github/workflows/driver-cross-build.yml
+++ b/.github/workflows/driver-cross-build.yml
@@ -35,9 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - { RPI_LINUX_VER: rpi-5.4.y, CONFIG_FILE: config-5.4.83-v7+, RPI_LINUX_COMMIT_HASH: 76c49e6, GCC_VER: 6.3 }
           - { RPI_LINUX_VER: rpi-5.4.y, CONFIG_FILE: config-5.4.83-v7+, RPI_LINUX_COMMIT_HASH: 76c49e6, GCC_VER: 8.3 }
-          - { RPI_LINUX_VER: rpi-5.10.y, CONFIG_FILE: config-5.10.11-v7+, RPI_LINUX_COMMIT_HASH: 6af8ae3, GCC_VER: 6.3 }
           - { RPI_LINUX_VER: rpi-5.10.y, CONFIG_FILE: config-5.10.11-v7+, RPI_LINUX_COMMIT_HASH: 6af8ae3, GCC_VER: 8.3 }
           - { RPI_LINUX_VER: rpi-5.15.y, CONFIG_FILE: config-5.15.61-v7l+, RPI_LINUX_COMMIT_HASH: 5b775d7, GCC_VER: 10.2 }
           - { RPI_LINUX_VER: rpi-5.15.y, CONFIG_FILE: config-5.15.76-v7l+, RPI_LINUX_COMMIT_HASH: 45d339389bb85588b8045dd40a00c54d01e2e711, GCC_VER: 10.2 }


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

GCC 6.3を使用するビルドテストを削除します。

GCC 6.3はDebian Stretch で使用するものであり、Stretchはサポート終了済みのため、
ビルドテスト対象から取り除いても問題ないと考えます。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
CIがすべて通ることを確認します。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
