### PR TITLE
CIの構築環境がRaspberry Piのバージョンによって分岐されるように処理を追加

### DIFF
--- a/.github/workflows/driver-cross-build.yml
+++ b/.github/workflows/driver-cross-build.yml
@@ -36,11 +36,22 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - { HOST: 20.04, KERNEL_VER: rpi-5.4.y, OS_BIT: armhf }  # Debian 10 (Buster)
-          - { HOST: 20.04, KERNEL_VER: rpi-5.10.y, OS_BIT: armhf }  # Debian 11 (Bullseye)
-          - { HOST: 22.04, KERNEL_VER: rpi-5.15.y, OS_BIT: armhf }  # Debian 11 (Bullseye)
-          - { HOST: 24.04, KERNEL_VER: rpi-6.6.y, OS_BIT: armhf }  # Debian 12 (Bookworm) 32-bit
-          - { HOST: 24.04, KERNEL_VER: rpi-6.6.y, OS_BIT: arm64 }  # Debian 12 (Bookworm) 64-bit
+          # Debian 10 (Buster)
+          - { HOST: 20.04, KERNEL_VER: rpi-5.4.y, OS_BIT: armhf, RASPI: 3}
+          - { HOST: 20.04, KERNEL_VER: rpi-5.4.y, OS_BIT: armhf, RASPI: 4}
+          # Debian 11 (Bullseye)
+          - { HOST: 20.04, KERNEL_VER: rpi-5.10.y, OS_BIT: armhf, RASPI: 3}
+          - { HOST: 20.04, KERNEL_VER: rpi-5.10.y, OS_BIT: armhf, RASPI: 4}
+          # Debian 11 (Bullseye)
+          - { HOST: 22.04, KERNEL_VER: rpi-5.15.y, OS_BIT: armhf, RASPI: 3}
+          - { HOST: 22.04, KERNEL_VER: rpi-5.15.y, OS_BIT: armhf, RASPI: 4}
+          # Debian 12 (Bookworm) 32-bit
+          - { HOST: 24.04, KERNEL_VER: rpi-6.6.y, OS_BIT: armhf, RASPI: 3}
+          - { HOST: 24.04, KERNEL_VER: rpi-6.6.y, OS_BIT: armhf, RASPI: 4}
+          # Debian 12 (Bookworm) 64-bit
+          - { HOST: 24.04, KERNEL_VER: rpi-6.6.y, OS_BIT: arm64, RASPI: 3}
+          - { HOST: 24.04, KERNEL_VER: rpi-6.6.y, OS_BIT: arm64, RASPI: 4}
+
 
     runs-on: ubuntu-${{ matrix.env.HOST }}
 
@@ -63,8 +74,13 @@ jobs:
         git clone --branch ${{ matrix.env.KERNEL_VER }} --depth=1 https://github.com/raspberrypi/linux
         cd linux
         if [ "${{ matrix.env.OS_BIT }}" == "armhf" ]; then
-          KERNEL=kernel7l
-          make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2711_defconfig
+          if [ "${{ matrix.env.RASPI }}" == "3" ]; then
+            KERNEL=kernel7
+            make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2709_defconfig
+          elif [ "${{ matrix.env.RASPI }}" == "4" ]; then
+            KERNEL=kernel7l
+            make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2711_defconfig
+          fi
           make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- modules_prepare
         else
           KERNEL=kernel8


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

CIによって構築される環境をRaspberry Piのバージョンに合わせて分岐するように修正しました。
現状ではRaspberry Pi 3と4に対応しています。

変数の指定やmakeコマンドが3と4で違うため、分岐処理を追加しました。OSのビット数やラズパイの型番による変数・makeコマンドの対応表は[ラズパイ公式のビルド手順の資料](https://www.raspberrypi.com/documentation/computers/linux_kernel.html#cross-compile-the-kernel)を参照しています。


# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

GitHub上のCIでパスが通ることを確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
