### PR TITLE
エラーハンドリング時のリソースリークが起こり得る箇所の修正

### DIFF
--- a/src/drivers/rtmouse_dev.c
+++ b/src/drivers/rtmouse_dev.c
@@ -59,6 +59,7 @@ static int i2c_counter_set(struct rtcnt_device_info *dev_info, int setval)
 		printk(KERN_ERR
 		       "%s: Failed writing to i2c counter device, addr=0x%x\n",
 		       __func__, client->addr);
+		mutex_unlock(&dev_info->lock);
 		return -ENODEV;
 	}
 	// printk(KERN_INFO "set 0x%x lsb = 0x%x\n", client->addr, lsb);
@@ -67,6 +68,7 @@ static int i2c_counter_set(struct rtcnt_device_info *dev_info, int setval)
 		printk(KERN_ERR
 		       "%s: Failed writing to i2c counter device, addr=0x%x\n",
 		       __func__, client->addr);
+		mutex_unlock(&dev_info->lock);
 		return -ENODEV;
 	}
 	mutex_unlock(&dev_info->lock);
@@ -90,6 +92,7 @@ static int i2c_counter_read(struct rtcnt_device_info *dev_info, int *ret)
 		    KERN_ERR
 		    "%s: Failed reading from i2c counter device, addr=0x%x\n",
 		    __func__, client->addr);
+		mutex_unlock(&dev_info->lock);
 		return -ENODEV;
 	}
 	msb = i2c_smbus_read_byte_data(client, CNT_ADDR_MSB);
@@ -98,6 +101,7 @@ static int i2c_counter_read(struct rtcnt_device_info *dev_info, int *ret)
 		    KERN_ERR
 		    "%s: Failed reading from i2c counter device, addr=0x%x\n",
 		    __func__, client->addr);
+		mutex_unlock(&dev_info->lock);
 		return -ENODEV;
 	}
 	mutex_unlock(&dev_info->lock);


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

エラーハンドリングをした際にmutex_unlock(&dev_info->lock);が呼ばれず、リソースリークを起こす可能性があるため、returnの前に追加します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

以下の環境で動作を確認しました。

- Raspberry 4B (4GB)
    - Ubuntu 24.04 64bit 6.8.0-1014-raspi
    - Ubuntu 22.04 64bit 5.15.0-1063-raspi
    - RaspiOS 64bit 6.6.51+rpt-rpi-v8
    - RaspiOS 32bit 6.6.62+rpt-rpi-v7l

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
