### PR TITLE
RaspberryPi OSカーネルrpi-6.12への対応

### DIFF
--- a/.github/workflows/driver-cross-build.yml
+++ b/.github/workflows/driver-cross-build.yml
@@ -36,12 +36,6 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          # Debian 10 (Buster)
-          - { HOST: 20.04, KERNEL_VER: rpi-5.4.y, OS_BIT: armhf, RASPI: 3}
-          - { HOST: 20.04, KERNEL_VER: rpi-5.4.y, OS_BIT: armhf, RASPI: 4}
-          # Debian 11 (Bullseye)
-          - { HOST: 20.04, KERNEL_VER: rpi-5.10.y, OS_BIT: armhf, RASPI: 3}
-          - { HOST: 20.04, KERNEL_VER: rpi-5.10.y, OS_BIT: armhf, RASPI: 4}
           # Debian 11 (Bullseye)
           - { HOST: 22.04, KERNEL_VER: rpi-5.15.y, OS_BIT: armhf, RASPI: 3}
           - { HOST: 22.04, KERNEL_VER: rpi-5.15.y, OS_BIT: armhf, RASPI: 4}

--- a/src/drivers/rtmouse.h
+++ b/src/drivers/rtmouse.h
@@ -52,7 +52,7 @@
 // Raspberry Pi 2 B        : 2
 // Raspberry Pi 3 B/A+/B+  : 2
 // Raspberry Pi 4 B        : 4
-#define RASPBERRYPI 2
+#define RASPBERRYPI 4
 
 #define DEV_RIGHT 0
 #define DEV_LEFT 1

--- a/src/drivers/rtmouse.h
+++ b/src/drivers/rtmouse.h
@@ -52,7 +52,7 @@
 // Raspberry Pi 2 B        : 2
 // Raspberry Pi 3 B/A+/B+  : 2
 // Raspberry Pi 4 B        : 4
-#define RASPBERRYPI 4
+#define RASPBERRYPI 2
 
 #define DEV_RIGHT 0
 #define DEV_LEFT 1

--- a/src/drivers/rtmouse_dev.c
+++ b/src/drivers/rtmouse_dev.c
@@ -189,7 +189,7 @@ static unsigned int mcp3204_get_value(int channel)
 	dev = mcp320x_dev;
 
 #else
-	struct spi_controller *controller;
+	struct spi_controller *master;
 	master = spi_busnum_to_master(mcp3204_info.bus_num);
 	snprintf(str, sizeof(str), "%s.%u", dev_name(&master->dev),
 		 mcp3204_info.chip_select);

--- a/src/drivers/rtmouse_dev.c
+++ b/src/drivers/rtmouse_dev.c
@@ -189,7 +189,7 @@ static unsigned int mcp3204_get_value(int channel)
 	dev = mcp320x_dev;
 
 #else
-	struct spi_master *master;
+	struct spi_controller *controller;
 	master = spi_busnum_to_master(mcp3204_info.bus_num);
 	snprintf(str, sizeof(str), "%s.%u", dev_name(&master->dev),
 		 mcp3204_info.chip_select);

--- a/src/drivers/rtmouse_spi.c
+++ b/src/drivers/rtmouse_spi.c
@@ -148,7 +148,7 @@ static int mcp3204_probe(struct spi_device *spi)
  * spi_remove_device - remove SPI device
  * called by mcp3204_init() and mcp3204_exit()
  */
-static void spi_remove_device(struct spi_master *master, unsigned int cs)
+static void spi_remove_device(struct spi_controller *master, unsigned int cs)
 {
 	struct device *dev;
 	char str[128];
@@ -188,7 +188,7 @@ int mcp3204_init(void)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
 	bus_for_each_dev(&spi_bus_type, NULL, NULL, __callback_find_mcp3204);
 #else
-	struct spi_master *master;
+	struct spi_controller *master;
 	struct spi_device *spi_device;
 
 	spi_register_driver(&mcp3204_driver);
@@ -231,7 +231,7 @@ void mcp3204_exit(void)
 		mcp3204_remove(to_spi_device(mcp320x_dev));
 	}
 #else
-	struct spi_master *master;
+	struct spi_controller *master;
 	master = spi_busnum_to_master(mcp3204_info.bus_num);
 
 	if (master) {


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

Raspberry Pi OSのカーネル`rpi-6.12`系に対応します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

https://github.com/rt-net/RaspberryPiMouse/issues/98

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

Raspberry Pi Mouse V3の実機でビルドし、サンプルプログラム（step.1~6）の動作を確認しました。

## 動作環境

以下の環境で動作を確認しました。

- Raspberry Pi Mouse V3
  - Raspberry Pi 4B+ (4GB)
- OS 
  - Raspberry Pi OS (64bit)
    - 6.12.25+rpt-rpi-v8
  - Ubuntu Server 24.04
    - 6.8.0-1028-raspi
  - Ubuntu Server 22.04
    - 5.15.0-1077-raspi

# Any other comments?
<!-- その他コメントはありますか？ -->

[GitHub ActionsのUbuntu 20.04サポート終了](https://github.com/actions/runner-images/issues/11101)に伴い、worlfowsのファイルから該当構成を削除しました。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
